### PR TITLE
Fix user type

### DIFF
--- a/user.tf
+++ b/user.tf
@@ -7,7 +7,7 @@ resource "google_sql_user" "admin_user" {
 
   name     = local.admin_user
   password = random_password.admin_user.result
-  type     = "BUILT_IN"
+  type     = ""
 
   deletion_policy = null
 }

--- a/user.tf
+++ b/user.tf
@@ -7,7 +7,7 @@ resource "google_sql_user" "admin_user" {
 
   name     = local.admin_user
   password = random_password.admin_user.result
-  type     = ""
+  type     = "" # Equivalent of "BUILT_IN"
 
   deletion_policy = null
 }


### PR DESCRIPTION
Should fix this endless loop:
```terraform
  # module.candidates_db.google_sql_user.admin_user must be replaced
-/+ resource "google_sql_user" "admin_user" {
      - host     = "" -> null
      ~ id       = "postgres//primary1-psql13" -> (known after apply)
        name     = "postgres"
      ~ project  = "candidates-prod-123456" -> (known after apply)
      ~ type     = "" -> "BUILT_IN" # forces replacement
        # (2 unchanged attributes hidden)
    }
```